### PR TITLE
Skip pkgbase file on save/restore

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = kernel-modules-hook
 	pkgdesc = Keeps your system fully functional after a kernel upgrade
-	pkgver = 0.1.7
+	pkgver = 0.1.8
 	pkgrel = 1
 	url = https://github.com/saber-nyan/kernel-modules-hook
 	install = kernel-modules-hook.install
@@ -14,8 +14,8 @@ pkgbase = kernel-modules-hook
 	source = UNLICENSE
 	sha256sums = 4169b44c297ddb7aad2220c6eba7c7942e3396f92528c59617955ab5560cb4cf
 	sha256sums = 5d947290ef8c94b33c79c531e5615f4c9bea38e7649092d34af3bf0af5b1ca24
-	sha256sums = 900502d030e925fca6188b9448fbaf6562d6e23cd5c50938cdf00522825f76c2
-	sha256sums = f7ea2947c3fbe1510b3ea5cc5793b8197f0718dcb12daea3da9b27b3cf1c4116
+	sha256sums = a1bbe644b5285dbc66eb4f09b9752345920542e8510d79e76b66284d6f3afd78
+	sha256sums = 85912aedf141b000bba9233069e1e9d17a0971d180a62a39e8fb263cd959139b
 	sha256sums = 7e12e5df4bae12cb21581ba157ced20e1986a0508dd10d0e8a4ab9a4cf94e85c
 
 pkgname = kernel-modules-hook

--- a/10-linux-modules-post.hook
+++ b/10-linux-modules-post.hook
@@ -9,4 +9,4 @@ Description = Restoring Linux kernel modules...
 When = PostTransaction
 Depends = coreutils
 Depends = rsync
-Exec = /bin/sh -xc 'KVER="${KVER:-$(uname -r)}"; if test -e "/usr/lib/modules/backup/${KVER}"; then rsync -AHXal --ignore-existing "/usr/lib/modules/backup/${KVER}" /usr/lib/modules/; fi; rm -rf /usr/lib/modules/backup'
+Exec = /bin/sh -xc 'KVER="${KVER:-$(uname -r)}"; if test -e "/usr/lib/modules/backup/${KVER}"; then rsync -AHXal --exclude pkgbase --ignore-existing "/usr/lib/modules/backup/${KVER}" /usr/lib/modules/; fi; rm -rf /usr/lib/modules/backup'

--- a/10-linux-modules-pre.hook
+++ b/10-linux-modules-pre.hook
@@ -8,4 +8,4 @@ Target = usr/lib/modules/*/vmlinuz
 Description = Saving Linux kernel modules...
 When = PreTransaction
 Depends = rsync
-Exec = /bin/sh -c 'KVER="${KVER:-$(uname -r)}"; if test -e "/usr/lib/modules/${KVER}"; then rsync -AHXal --delete-after "/usr/lib/modules/${KVER}" /usr/lib/modules/backup/; fi'
+Exec = /bin/sh -c 'KVER="${KVER:-$(uname -r)}"; if test -e "/usr/lib/modules/${KVER}"; then rsync -AHXal --exclude pkgbase --delete-after "/usr/lib/modules/${KVER}" /usr/lib/modules/backup/; fi'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Artoria Pendragon <saber-nyan@ya.ru>
 # Hooks: https://www.reddit.com/r/archlinux/comments/4zrsc3/keep_your_system_fully_functional_after_a_kernel/d6yin0r/
 pkgname=kernel-modules-hook
-pkgver=0.1.7
+pkgver=0.1.8
 pkgrel=1
 pkgdesc="Keeps your system fully functional after a kernel upgrade"
 arch=('any')
@@ -16,8 +16,8 @@ source=("linux-modules-cleanup.conf"
 		"UNLICENSE")
 sha256sums=('4169b44c297ddb7aad2220c6eba7c7942e3396f92528c59617955ab5560cb4cf'
             '5d947290ef8c94b33c79c531e5615f4c9bea38e7649092d34af3bf0af5b1ca24'
-            '900502d030e925fca6188b9448fbaf6562d6e23cd5c50938cdf00522825f76c2'
-            'f7ea2947c3fbe1510b3ea5cc5793b8197f0718dcb12daea3da9b27b3cf1c4116'
+            'a1bbe644b5285dbc66eb4f09b9752345920542e8510d79e76b66284d6f3afd78'
+            '85912aedf141b000bba9233069e1e9d17a0971d180a62a39e8fb263cd959139b'
             '7e12e5df4bae12cb21581ba157ced20e1986a0508dd10d0e8a4ab9a4cf94e85c')
 
 package() {


### PR DESCRIPTION
This avoids problems with dracut-install hook.

Saving restoring the pkgbase file causes 2 (or more) kernels with the
same pkgbase to be present in /usr/lib/modules, which is not handled by
the dracut-install hook.